### PR TITLE
Update CsvHelper and Tables.Extensions package versions

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="CsvHelper" Version="33.0.1" />
+    <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
     <!-- Analyzers -->
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.0">

--- a/src/Medienstudio.Azure.Data.Tables.CSV/Directory.Packages.props
+++ b/src/Medienstudio.Azure.Data.Tables.CSV/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-	</PropertyGroup>
-	<Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
-	<ItemGroup>
-		<PackageVersion Include="Medienstudio.Azure.Data.Tables.Extensions" Version="1.4.1" />
-	</ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
+  <ItemGroup>
+    <PackageVersion Include="Medienstudio.Azure.Data.Tables.Extensions" Version="1.4.2" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Bumped CsvHelper to 33.1.0 and Medienstudio.Azure.Data.Tables.Extensions to 1.4.2 for latest features and fixes.