### PR TITLE
Fix CSV round-trip values

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+charset = utf-8

--- a/src/Medienstudio.Azure.Data.Tables.CSV.Tests/ExtensionTests.cs
+++ b/src/Medienstudio.Azure.Data.Tables.CSV.Tests/ExtensionTests.cs
@@ -16,7 +16,7 @@ public class ExtensionTests
     private TableServiceClient _tableServiceClient = null!;
     private TableClient _tableClient = null!;
 
-    private const string specialChars = "äöüßÄÖÜ#-.;:_!§$%&/()=?`´*'+~<>|@€{[]}\\^°²³";
+    private const string specialChars = "Ã¤Ã¶Ã¼ÃŸÃ„Ã–Ãœ#-.;:_!Â§$%&/()=?`Â´*'+~<>|@â‚¬{[]}\\^Â°Â²Â³";
 
     [TestInitialize]
     public void Initialize()
@@ -60,7 +60,7 @@ public class ExtensionTests
 
         string[] dataDateTimeOffset = lines[4].Split(',');
         Assert.AreEqual("partition", dataDateTimeOffset[0]);
-        Assert.AreEqual("2020-01-01T01:01:01Z", dataDateTimeOffset[9]);
+        Assert.AreEqual("2019-12-31T23:01:01Z", dataDateTimeOffset[9]);
         Assert.AreEqual("DateTime", dataDateTimeOffset[10]);
 
         string[] dataDouble = lines[5].Split(',');
@@ -164,6 +164,20 @@ public class ExtensionTests
         Assert.AreEqual(3003, rows.Count);
     }
 
+    [TestMethod]
+    public async Task TestImportPreservesEmptyValues()
+    {
+        const string csvContent = "PartitionKey,RowKey,emptyString,emptyString@type,emptyBinary,emptyBinary@type,emptyInt32,emptyInt32@type\r\npartition,empty,,String,,Binary,,Int32\r\n";
+        using StringReader reader = new(csvContent);
+
+        await _tableClient.ImportCSVAsync(reader);
+
+        TableEntity entity = (await _tableClient.GetEntityAsync<TableEntity>("partition", "empty")).Value;
+        Assert.AreEqual(string.Empty, entity.GetString("emptyString"));
+        CollectionAssert.AreEqual(Array.Empty<byte>(), entity.GetBinary("emptyBinary"));
+        Assert.IsFalse(entity.ContainsKey("emptyInt32"));
+    }
+
     private static string RandomTableName()
     {
         return "t" + Guid.NewGuid().ToString("N");
@@ -198,7 +212,7 @@ public class ExtensionTests
 
         // datetimeoffset
         TableEntity dateTimeOffsetEntity = new("partition", "04-datetimeoffset");
-        DateTimeOffset dateTimeOffset = new(2020, 1, 1, 1, 1, 1, TimeSpan.Zero);
+        DateTimeOffset dateTimeOffset = new(2020, 1, 1, 1, 1, 1, TimeSpan.FromHours(2));
         dateTimeOffsetEntity.Add("datetimeoffset", dateTimeOffset);
         _tableClient.AddEntity(dateTimeOffsetEntity);
 

--- a/src/Medienstudio.Azure.Data.Tables.CSV/Extensions.cs
+++ b/src/Medienstudio.Azure.Data.Tables.CSV/Extensions.cs
@@ -32,7 +32,7 @@ public static class Extensions
 
         // preserve milliseconds, truncate trailing zeros
         csv.Context.TypeConverterOptionsCache.GetOptions<DateTime>().Formats = ["yyyy-MM-ddTHH:mm:ss.FFFFFFFZ"];
-        csv.Context.TypeConverterOptionsCache.GetOptions<DateTimeOffset>().Formats = ["yyyy-MM-ddTHH:mm:ss.FFFFFFFZ"];
+        csv.Context.TypeConverterCache.AddConverter<DateTimeOffset>(new UtcDateTimeOffsetConverter());
 
 
         // serialize byte arrays as base64 strings
@@ -140,11 +140,6 @@ public static class Extensions
             int i = 0;
             while (csv.TryGetField(i, out string? field))
             {
-                if (string.IsNullOrEmpty(field))
-                {
-                    i++;
-                    continue;
-                }
                 string? label = csv.HeaderRecord?[i];
                 if (label == null)
                 {
@@ -153,6 +148,12 @@ public static class Extensions
 
                 if (SYSTEM_PROPERTIES.Contains(label))
                 {
+                    if (string.IsNullOrEmpty(field))
+                    {
+                        i++;
+                        continue;
+                    }
+
                     switch (label)
                     {
                         case "PartitionKey":
@@ -169,8 +170,11 @@ public static class Extensions
                 else if (!label.EndsWith(TYPE_SUFFIX))
                 {
                     string? type = csv.GetField<string>(label + "@type")?.Split('@')[0];
-                    object value = CoerceType(type, field);
-                    entity.Add(label, value);
+                    if (!string.IsNullOrEmpty(field) || type is "String" or "Binary")
+                    {
+                        object value = CoerceType(type, field ?? string.Empty);
+                        entity.Add(label, value);
+                    }
                 }
 
                 i++;

--- a/src/Medienstudio.Azure.Data.Tables.CSV/UtcDateTimeOffsetConverter.cs
+++ b/src/Medienstudio.Azure.Data.Tables.CSV/UtcDateTimeOffsetConverter.cs
@@ -1,0 +1,16 @@
+using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+using System.Globalization;
+
+namespace Medienstudio.Azure.Data.Tables.CSV;
+
+internal sealed class UtcDateTimeOffsetConverter : DateTimeOffsetConverter
+{
+    public override string? ConvertToString(object? value, IWriterRow row, MemberMapData memberMapData)
+    {
+        return value is DateTimeOffset dateTimeOffset
+            ? dateTimeOffset.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFFZ", CultureInfo.InvariantCulture)
+            : base.ConvertToString(value, row, memberMapData);
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize exported `DateTimeOffset` values to UTC before adding the `Z` suffix.
- Preserve empty typed CSV values during import.
- Cover non-UTC timestamps plus empty string and binary values.

## Validation
- `dotnet test src/Medienstudio.Azure.Data.Tables.CSV.Tests/Medienstudio.Azure.Data.Tables.CSV.Tests.csproj --no-restore` (5 passed)