### PR TITLE
Add CSV export schema support

### DIFF
--- a/src/Medienstudio.Azure.Data.Tables.CSV.Tests/ExtensionTests.cs
+++ b/src/Medienstudio.Azure.Data.Tables.CSV.Tests/ExtensionTests.cs
@@ -198,6 +198,118 @@ public class ExtensionTests
     }
 
     [TestMethod]
+    public async Task TestStoredCsvExportSchema()
+    {
+        TableClient metadataTableClient = _tableServiceClient.GetTableClient(RandomTableName());
+        metadataTableClient.CreateIfNotExists();
+        try
+        {
+            Assert.IsNull(await _tableClient.GetStoredCSVExportSchemaAsync(metadataTableClient));
+
+            CsvExportSchema schema = new(["first", "second"]);
+            await _tableClient.StoreCSVExportSchemaAsync(metadataTableClient, schema);
+
+            CsvExportSchema? storedSchema = await _tableClient.GetStoredCSVExportSchemaAsync(metadataTableClient);
+            Assert.IsNotNull(storedSchema);
+            CollectionAssert.AreEqual(schema.Properties.ToArray(), storedSchema.Properties.ToArray());
+
+            CsvExportSchema replacementSchema = new(["replacement"]);
+            await _tableClient.StoreCSVExportSchemaAsync(metadataTableClient, replacementSchema);
+
+            storedSchema = await _tableClient.GetStoredCSVExportSchemaAsync(metadataTableClient);
+            Assert.IsNotNull(storedSchema);
+            CollectionAssert.AreEqual(replacementSchema.Properties.ToArray(), storedSchema.Properties.ToArray());
+        }
+        finally
+        {
+            metadataTableClient.Delete();
+        }
+    }
+
+    [TestMethod]
+    public async Task TestStoredCsvExportSchemaRequiresSeparateTable()
+    {
+        CsvExportSchema schema = new([]);
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _tableClient.StoreCSVExportSchemaAsync(_tableClient, schema));
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _tableClient.GetStoredCSVExportSchemaAsync(_tableClient));
+    }
+
+    [TestMethod]
+    public async Task TestGetStoredCsvExportSchemaThrowsWhenSchemaJsonMissing()
+    {
+        TableClient metadataTableClient = _tableServiceClient.GetTableClient(RandomTableName());
+        metadataTableClient.CreateIfNotExists();
+        try
+        {
+            await _tableClient.StoreCSVExportSchemaAsync(metadataTableClient, new CsvExportSchema(["value"]));
+            TableEntity metadata = await GetSingleMetadataEntityAsync(metadataTableClient);
+
+            // replace the entity without a SchemaJson property
+            await metadataTableClient.UpsertEntityAsync(new TableEntity(metadata.PartitionKey, metadata.RowKey), TableUpdateMode.Replace);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _tableClient.GetStoredCSVExportSchemaAsync(metadataTableClient));
+        }
+        finally
+        {
+            metadataTableClient.Delete();
+        }
+    }
+
+    [TestMethod]
+    public async Task TestGetStoredCsvExportSchemaThrowsWhenSchemaJsonIsMalformed()
+    {
+        TableClient metadataTableClient = _tableServiceClient.GetTableClient(RandomTableName());
+        metadataTableClient.CreateIfNotExists();
+        try
+        {
+            await _tableClient.StoreCSVExportSchemaAsync(metadataTableClient, new CsvExportSchema(["value"]));
+            TableEntity metadata = await GetSingleMetadataEntityAsync(metadataTableClient);
+
+            TableEntity corrupted = new(metadata.PartitionKey, metadata.RowKey) { ["SchemaJson"] = "not-json" };
+            await metadataTableClient.UpsertEntityAsync(corrupted, TableUpdateMode.Replace);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _tableClient.GetStoredCSVExportSchemaAsync(metadataTableClient));
+        }
+        finally
+        {
+            metadataTableClient.Delete();
+        }
+    }
+
+    [TestMethod]
+    public async Task TestGetStoredCsvExportSchemaThrowsWhenStoredPropertiesAreInvalid()
+    {
+        TableClient metadataTableClient = _tableServiceClient.GetTableClient(RandomTableName());
+        metadataTableClient.CreateIfNotExists();
+        try
+        {
+            await _tableClient.StoreCSVExportSchemaAsync(metadataTableClient, new CsvExportSchema(["value"]));
+            TableEntity metadata = await GetSingleMetadataEntityAsync(metadataTableClient);
+
+            // "PartitionKey" is a reserved property name that CsvExportSchema rejects
+            TableEntity corrupted = new(metadata.PartitionKey, metadata.RowKey) { ["SchemaJson"] = "[\"PartitionKey\"]" };
+            await metadataTableClient.UpsertEntityAsync(corrupted, TableUpdateMode.Replace);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _tableClient.GetStoredCSVExportSchemaAsync(metadataTableClient));
+        }
+        finally
+        {
+            metadataTableClient.Delete();
+        }
+    }
+
+    private static async Task<TableEntity> GetSingleMetadataEntityAsync(TableClient metadataTableClient)
+    {
+        await foreach (TableEntity entity in metadataTableClient.QueryAsync<TableEntity>())
+        {
+            return entity;
+        }
+
+        throw new InvalidOperationException("Expected a stored metadata entity.");
+    }
+
+    [TestMethod]
     public void TestCsvExportSchemaValidation()
     {
         Assert.ThrowsException<ArgumentNullException>(() => new CsvExportSchema(null!));
@@ -392,6 +504,12 @@ public class ExtensionTests
         {
             Mutate();
             base.Write(buffer, index, count);
+        }
+
+        public override void Write(ReadOnlySpan<char> buffer)
+        {
+            Mutate();
+            base.Write(buffer);
         }
 
         private void Mutate()

--- a/src/Medienstudio.Azure.Data.Tables.CSV.Tests/ExtensionTests.cs
+++ b/src/Medienstudio.Azure.Data.Tables.CSV.Tests/ExtensionTests.cs
@@ -117,20 +117,126 @@ public class ExtensionTests
     }
 
     [TestMethod]
+    public async Task TestExportWithSchema()
+    {
+        CreateTestData();
+        CsvExportSchema schema = await _tableClient.GetCSVExportSchemaAsync();
+        CollectionAssert.AreEqual(new[] { "binary", "bool", "datetime", "datetimeoffset", "double", "guid", "int", "long", "specialChars", "quotes" }, schema.Properties.ToArray());
+
+        string defaultExport = await ExportToStringAsync(writer => _tableClient.ExportCSVAsync(writer));
+        string schemaExport = await ExportToStringAsync(writer => _tableClient.ExportCSVAsync(writer, schema));
+
+        string header = schemaExport.Split("\r\n")[0];
+        Assert.AreEqual("PartitionKey,RowKey,Timestamp,binary,binary@type,bool,bool@type,datetime,datetime@type,datetimeoffset,datetimeoffset@type,double,double@type,guid,guid@type,int,int@type,long,long@type,specialChars,specialChars@type,quotes,quotes@type", header);
+        Assert.AreEqual(defaultExport, schemaExport);
+    }
+
+    [TestMethod]
+    public async Task TestExportInMemory()
+    {
+        CreateTestData();
+        string defaultExport = await ExportToStringAsync(writer => _tableClient.ExportCSVAsync(writer));
+        string inMemoryExport = await ExportToStringAsync(writer => _tableClient.ExportCSVInMemoryAsync(writer));
+
+        string[] lines = inMemoryExport.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        Assert.AreEqual(11, lines.Length);
+        Assert.AreEqual("PartitionKey,RowKey,Timestamp,binary,binary@type,bool,bool@type,datetime,datetime@type,datetimeoffset,datetimeoffset@type,double,double@type,guid,guid@type,int,int@type,long,long@type,specialChars,specialChars@type,quotes,quotes@type", lines[0]);
+        Assert.AreEqual(defaultExport, inMemoryExport);
+    }
+
+    [TestMethod]
+    public async Task TestExportEmptyTable()
+    {
+        CsvExportSchema schema = await _tableClient.GetCSVExportSchemaAsync();
+        Assert.AreEqual(0, schema.Properties.Count);
+
+        string defaultExport = await ExportToStringAsync(writer => _tableClient.ExportCSVAsync(writer));
+        string schemaExport = await ExportToStringAsync(writer => _tableClient.ExportCSVAsync(writer, schema));
+        string inMemoryExport = await ExportToStringAsync(writer => _tableClient.ExportCSVInMemoryAsync(writer));
+
+        Assert.AreEqual("PartitionKey,RowKey,Timestamp\r\n", defaultExport);
+        Assert.AreEqual(defaultExport, schemaExport);
+        Assert.AreEqual(defaultExport, inMemoryExport);
+    }
+
+    [TestMethod]
+    public async Task TestExportExcludesODataEtag()
+    {
+        TableEntity entity = new("partition", "etag")
+        {
+            { "odata.etag", "ignored" },
+            { "value", "included" }
+        };
+        _tableClient.AddEntity(entity);
+
+        CsvExportSchema schema = await _tableClient.GetCSVExportSchemaAsync();
+        CollectionAssert.AreEqual(new[] { "value" }, schema.Properties.ToArray());
+
+        string export = await ExportToStringAsync(writer => _tableClient.ExportCSVAsync(writer));
+        Assert.IsFalse(export.Contains("odata.etag", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task TestExportDetectsSchemaDrift()
+    {
+        _tableClient.AddEntity(new TableEntity("partition", "initial") { { "known", "value" } });
+        using MutatingStringWriter writer = new(() => _tableClient.AddEntity(new TableEntity("partition", "new") { { "unknown", "value" } }));
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _tableClient.ExportCSVAsync(writer));
+    }
+
+    [TestMethod]
+    public async Task TestExportWithIncompleteSchema()
+    {
+        TableEntity entity = new("partition", "incomplete")
+        {
+            { "value", 1 }
+        };
+        _tableClient.AddEntity(entity);
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _tableClient.ExportCSVAsync(TextWriter.Null, new CsvExportSchema([])));
+    }
+
+    [TestMethod]
+    public void TestCsvExportSchemaValidation()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => new CsvExportSchema(null!));
+        Assert.ThrowsException<ArgumentException>(() => new CsvExportSchema(new string[] { null! }));
+        Assert.ThrowsException<ArgumentException>(() => new CsvExportSchema([" "]));
+        Assert.ThrowsException<ArgumentException>(() => new CsvExportSchema(["value", "value"]));
+        Assert.ThrowsException<ArgumentException>(() => new CsvExportSchema(["PartitionKey"]));
+        Assert.ThrowsException<ArgumentException>(() => new CsvExportSchema(["RowKey"]));
+        Assert.ThrowsException<ArgumentException>(() => new CsvExportSchema(["Timestamp"]));
+        Assert.ThrowsException<ArgumentException>(() => new CsvExportSchema(["odata.etag"]));
+    }
+
+    [TestMethod]
     public async Task TestImportFile()
     {
-        using StreamReader reader = new("test.csv");
+        TableClient sourceTableClient = _tableServiceClient.GetTableClient(RandomTableName());
+        sourceTableClient.CreateIfNotExists();
+        string sourceCsv;
+        try
+        {
+            CreateTestData(sourceTableClient);
+            sourceCsv = await ExportToStringAsync(writer => sourceTableClient.ExportCSVAsync(writer));
+        }
+        finally
+        {
+            sourceTableClient.Delete();
+        }
+
+        using StringReader reader = new(sourceCsv);
         await _tableClient.ImportCSVAsync(reader);
 
-        using StreamWriter writer = File.CreateText("output.csv");
-        await _tableClient.ExportCSVAsync(writer);
+        string outputCsv = await ExportToStringAsync(writer => _tableClient.ExportCSVAsync(writer));
 
-        using StreamReader reader1 = new("test.csv");
+        using StringReader reader1 = new(sourceCsv);
         using CsvReader csv1 = new(reader1, CultureInfo.InvariantCulture);
         csv1.Read();
         csv1.ReadHeader();
 
-        using StreamReader reader2 = new("output.csv");
+        using StringReader reader2 = new(outputCsv);
         using CsvReader csv2 = new(reader2, CultureInfo.InvariantCulture);
         csv2.Read();
         csv2.ReadHeader();
@@ -183,9 +289,17 @@ public class ExtensionTests
         return "t" + Guid.NewGuid().ToString("N");
     }
 
-    private void CreateTestData()
+    private static async Task<string> ExportToStringAsync(Func<TextWriter, Task> export)
     {
-        if (_tableClient is null)
+        using StringWriter writer = new(CultureInfo.InvariantCulture);
+        await export(writer);
+        return writer.ToString();
+    }
+
+    private void CreateTestData(TableClient? targetTableClient = null)
+    {
+        TableClient tableClient = targetTableClient ?? _tableClient;
+        if (tableClient is null)
             return;
 
         // supported property types
@@ -195,67 +309,96 @@ public class ExtensionTests
         TableEntity binaryEntity = new("partition", "01-binary");
         byte[] binary = Encoding.UTF8.GetBytes("binary");
         binaryEntity.Add("binary", binary);
-        _tableClient.AddEntity(binaryEntity);
+        tableClient.AddEntity(binaryEntity);
 
         // bool
         TableEntity boolEntity = new("partition", "02-bool")
         {
             { "bool", true }
         };
-        _tableClient.AddEntity(boolEntity);
+        tableClient.AddEntity(boolEntity);
 
         // datetime
         TableEntity dateTimeEntity = new("partition", "03-datetime");
         DateTime dateTime = new(2020, 1, 1, 1, 1, 1, DateTimeKind.Utc);
         dateTimeEntity.Add("datetime", dateTime);
-        _tableClient.AddEntity(dateTimeEntity);
+        tableClient.AddEntity(dateTimeEntity);
 
         // datetimeoffset
         TableEntity dateTimeOffsetEntity = new("partition", "04-datetimeoffset");
         DateTimeOffset dateTimeOffset = new(2020, 1, 1, 1, 1, 1, TimeSpan.FromHours(2));
         dateTimeOffsetEntity.Add("datetimeoffset", dateTimeOffset);
-        _tableClient.AddEntity(dateTimeOffsetEntity);
+        tableClient.AddEntity(dateTimeOffsetEntity);
 
         // double
         TableEntity doubleEntity = new("partition", "05-double")
         {
             { "double", 1.1 }
         };
-        _tableClient.AddEntity(doubleEntity);
+        tableClient.AddEntity(doubleEntity);
 
         // guid
         TableEntity guidEntity = new("partition", "06-guid");
         Guid guid = Guid.NewGuid();
         guidEntity.Add("guid", guid);
-        _tableClient.AddEntity(guidEntity);
+        tableClient.AddEntity(guidEntity);
 
         // int32
         TableEntity intEntity = new("partition", "07-int")
         {
             { "int", 1 }
         };
-        _tableClient.AddEntity(intEntity);
+        tableClient.AddEntity(intEntity);
 
         // int64
         TableEntity longEntity = new("partition", "08-long")
         {
             { "long", 1L }
         };
-        _tableClient.AddEntity(longEntity);
+        tableClient.AddEntity(longEntity);
 
         // special chars
         TableEntity specialCharsEntity = new("partition", "09-specialChars")
         {
             { "specialChars", specialChars }
         };
-        _tableClient.AddEntity(specialCharsEntity);
+        tableClient.AddEntity(specialCharsEntity);
 
         // quotes
         TableEntity quotesEntity = new("partition", "10-quotes")
         {
             { "quotes",  "string with \"quotes\""}
         };
-        _tableClient.AddEntity(quotesEntity);
+        tableClient.AddEntity(quotesEntity);
+    }
+
+    private sealed class MutatingStringWriter(Action mutation) : StringWriter
+    {
+        private Action? _mutation = mutation;
+
+        public override void Write(char value)
+        {
+            Mutate();
+            base.Write(value);
+        }
+
+        public override void Write(string? value)
+        {
+            Mutate();
+            base.Write(value);
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            Mutate();
+            base.Write(buffer, index, count);
+        }
+
+        private void Mutate()
+        {
+            Action? mutation = Interlocked.Exchange(ref _mutation, null);
+            mutation?.Invoke();
+        }
     }
 
     [TestCleanup]

--- a/src/Medienstudio.Azure.Data.Tables.CSV/CsvExportSchema.cs
+++ b/src/Medienstudio.Azure.Data.Tables.CSV/CsvExportSchema.cs
@@ -1,0 +1,41 @@
+namespace Medienstudio.Azure.Data.Tables.CSV;
+
+/// <summary>
+/// Describes the non-system properties included in a CSV export.
+/// </summary>
+public sealed class CsvExportSchema
+{
+    private static readonly string[] ReservedPropertyNames = ["PartitionKey", "RowKey", "Timestamp", "odata.etag"];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CsvExportSchema"/> class.
+    /// </summary>
+    /// <param name="properties">The non-system property names to include in the CSV export.</param>
+    public CsvExportSchema(IEnumerable<string> properties)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+
+        string[] propertyNames = properties.ToArray();
+        if (propertyNames.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException("Property names cannot be null, empty, or whitespace.", nameof(properties));
+        }
+
+        if (propertyNames.Distinct(StringComparer.Ordinal).Count() != propertyNames.Length)
+        {
+            throw new ArgumentException("Property names must be unique.", nameof(properties));
+        }
+
+        if (propertyNames.Any(propertyName => ReservedPropertyNames.Contains(propertyName, StringComparer.Ordinal)))
+        {
+            throw new ArgumentException("System properties cannot be included in a CSV export schema.", nameof(properties));
+        }
+
+        Properties = Array.AsReadOnly(propertyNames);
+    }
+
+    /// <summary>
+    /// Gets the non-system property names in CSV column order.
+    /// </summary>
+    public IReadOnlyList<string> Properties { get; }
+}

--- a/src/Medienstudio.Azure.Data.Tables.CSV/Extensions.cs
+++ b/src/Medienstudio.Azure.Data.Tables.CSV/Extensions.cs
@@ -152,7 +152,7 @@ public static class Extensions
         // serialize byte arrays as base64 strings
         csv.Context.TypeConverterCache.AddConverter<byte[]>(new BinaryConverter());
 
-        // serilaize booleans lowercase
+        // serialize booleans lowercase
         csv.Context.TypeConverterCache.AddConverter<bool>(new BoolConverter());
 
         return csv;

--- a/src/Medienstudio.Azure.Data.Tables.CSV/Extensions.cs
+++ b/src/Medienstudio.Azure.Data.Tables.CSV/Extensions.cs
@@ -22,13 +22,127 @@ public static class Extensions
     /// <returns>Task<void></void></returns>
     public static async Task ExportCSVAsync(this TableClient tableClient, TextWriter writer)
     {
-        List<TableEntity> rows = [];
-        List<string> systemProperties = ["PartitionKey", "RowKey", "Timestamp"];
-        List<string> keys = [];
-        keys.AddRange(systemProperties);
-        List<string> ignore = ["odata.etag"];
+        CsvExportSchema schema = await tableClient.GetCSVExportSchemaAsync();
+        await tableClient.ExportCSVAsync(writer, schema);
+    }
 
-        using CsvWriter csv = new(writer, CultureInfo.InvariantCulture);
+    /// <summary>
+    /// Returns the CSV export schema discovered from all entities in the table.
+    /// </summary>
+    /// <param name="tableClient">The authenticated TableClient</param>
+    /// <returns>The non-system properties in the order they are first encountered.</returns>
+    public static async Task<CsvExportSchema> GetCSVExportSchemaAsync(this TableClient tableClient)
+    {
+        HashSet<string> knownProperties = new(StringComparer.Ordinal);
+        List<string> properties = [];
+
+        await foreach (TableEntity row in tableClient.QueryAsync<TableEntity>())
+        {
+            AddProperties(row, knownProperties, properties);
+        }
+
+        return new CsvExportSchema(properties);
+    }
+
+    /// <summary>
+    /// Returns all rows in the table as CSV to the provided writer after buffering them in memory.
+    /// </summary>
+    /// <param name="tableClient">The authenticated TableClient</param>
+    /// <param name="writer">TextWriter instance that takes the serialized result</param>
+    /// <returns>Task<void></void></returns>
+    /// <remarks>Use this method only when the table fits comfortably in memory. It queries the table once and buffers every entity before writing.</remarks>
+    public static async Task ExportCSVInMemoryAsync(this TableClient tableClient, TextWriter writer)
+    {
+        List<TableEntity> rows = [];
+        await foreach (TableEntity row in tableClient.QueryAsync<TableEntity>())
+        {
+            rows.Add(row);
+        }
+
+        CsvExportSchema schema = CreateCSVExportSchema(rows);
+        WriteCSV(writer, schema, rows);
+    }
+
+    /// <summary>
+    /// Returns all rows in the table as CSV to the provided writer using the supplied schema.
+    /// </summary>
+    /// <param name="tableClient">The authenticated TableClient</param>
+    /// <param name="writer">TextWriter instance that takes the serialized result</param>
+    /// <param name="schema">The non-system properties to include in the CSV export.</param>
+    /// <returns>Task<void></void></returns>
+    /// <exception cref="InvalidOperationException">An entity contains a property that is absent from <paramref name="schema"/>.</exception>
+    public static async Task ExportCSVAsync(this TableClient tableClient, TextWriter writer, CsvExportSchema schema)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        List<string> keys = CreateCSVKeys(schema);
+        HashSet<string> schemaProperties = schema.Properties.ToHashSet(StringComparer.Ordinal);
+
+        using CsvWriter csv = CreateCSVWriter(writer);
+        WriteCSVHeader(csv, keys);
+
+        await foreach (TableEntity row in tableClient.QueryAsync<TableEntity>())
+        {
+            WriteCSVRow(csv, keys, schemaProperties, row);
+        }
+
+        csv.Flush();
+    }
+
+    private static CsvExportSchema CreateCSVExportSchema(IEnumerable<TableEntity> rows)
+    {
+        HashSet<string> knownProperties = new(StringComparer.Ordinal);
+        List<string> properties = [];
+
+        foreach (TableEntity row in rows)
+        {
+            AddProperties(row, knownProperties, properties);
+        }
+
+        return new CsvExportSchema(properties);
+    }
+
+    private static void AddProperties(TableEntity row, HashSet<string> knownProperties, List<string> properties)
+    {
+        foreach (KeyValuePair<string, object> property in row)
+        {
+            if (IsExportedProperty(property.Key) && knownProperties.Add(property.Key))
+            {
+                properties.Add(property.Key);
+            }
+        }
+    }
+
+    private static void WriteCSV(TextWriter writer, CsvExportSchema schema, IEnumerable<TableEntity> rows)
+    {
+        List<string> keys = CreateCSVKeys(schema);
+        HashSet<string> schemaProperties = schema.Properties.ToHashSet(StringComparer.Ordinal);
+
+        using CsvWriter csv = CreateCSVWriter(writer);
+        WriteCSVHeader(csv, keys);
+
+        foreach (TableEntity row in rows)
+        {
+            WriteCSVRow(csv, keys, schemaProperties, row);
+        }
+
+        csv.Flush();
+    }
+
+    private static List<string> CreateCSVKeys(CsvExportSchema schema)
+    {
+        List<string> keys = [.. SYSTEM_PROPERTIES];
+        foreach (string property in schema.Properties)
+        {
+            keys.Add(property);
+            keys.Add(property + TYPE_SUFFIX);
+        }
+
+        return keys;
+    }
+
+    private static CsvWriter CreateCSVWriter(TextWriter writer)
+    {
+        CsvWriter csv = new(writer, CultureInfo.InvariantCulture);
 
         // preserve milliseconds, truncate trailing zeros
         csv.Context.TypeConverterOptionsCache.GetOptions<DateTime>().Formats = ["yyyy-MM-ddTHH:mm:ss.FFFFFFFZ"];
@@ -41,80 +155,59 @@ public static class Extensions
         // serilaize booleans lowercase
         csv.Context.TypeConverterCache.AddConverter<bool>(new BoolConverter());
 
+        return csv;
+    }
 
-        IAsyncEnumerable<global::Azure.Page<TableEntity>> query = tableClient.QueryAsync<TableEntity>().AsPages();
-
-        // loop through all result pages
-        await foreach (global::Azure.Page<TableEntity> page in query)
-        {
-            // loop through all rows in the page
-            foreach (TableEntity entity in page.Values)
-            {
-                // cache all rows
-                rows.Add(entity);
-
-                // prepare the list of keys for csv header
-                foreach (KeyValuePair<string, object> property in entity)
-                {
-                    // skip properties that should be ignored for the export like odata.etag
-                    if (ignore.Contains(property.Key))
-                    {
-                        continue;
-                    }
-                    // add the property key to the list of keys if it is not already in the list
-                    if (!keys.Contains(property.Key))
-                    {
-                        keys.Add(property.Key);
-                    }
-                    // add the type of the property to the list of keys if it is not a system property
-                    if (!systemProperties.Contains(property.Key) && !keys.Contains(property.Key + "@type"))
-                    {
-                        keys.Add(property.Key + "@type");
-                    }
-                }
-            }
-        }
-
-        // create the csv header
+    private static void WriteCSVHeader(CsvWriter csv, IEnumerable<string> keys)
+    {
         foreach (string key in keys)
         {
             csv.WriteField(key);
         }
         csv.NextRecord();
+    }
 
-        // create the csv rows
-        foreach (TableEntity row in rows)
+    private static void WriteCSVRow(CsvWriter csv, IEnumerable<string> keys, HashSet<string> schemaProperties, TableEntity row)
+    {
+        foreach (KeyValuePair<string, object> property in row)
         {
-            foreach (string key in keys)
+            if (IsExportedProperty(property.Key) && !schemaProperties.Contains(property.Key))
             {
-                if (row.TryGetValue(key, out object value))
-                {
-                    // write the value of the property
-                    csv.WriteField(value);
-                }
-                else if (key.EndsWith(TYPE_SUFFIX))
-                {
-                    // write the type of the property
-                    if (row.ContainsKey(key[..^TYPE_SUFFIX.Length]))
-                    {
-                        csv.WriteField(row[key[..^TYPE_SUFFIX.Length]].GetPropertyTypeName());
-                    }
-                    else
-                    {
-                        csv.WriteField("");
-                    }
+                throw new InvalidOperationException($"The property '{property.Key}' is not included in the CSV export schema.");
+            }
+        }
 
+        foreach (string key in keys)
+        {
+            if (row.TryGetValue(key, out object value))
+            {
+                // write the value of the property
+                csv.WriteField(value);
+            }
+            else if (key.EndsWith(TYPE_SUFFIX))
+            {
+                // write the type of the property
+                if (row.ContainsKey(key[..^TYPE_SUFFIX.Length]))
+                {
+                    csv.WriteField(row[key[..^TYPE_SUFFIX.Length]].GetPropertyTypeName());
                 }
                 else
                 {
-                    // write an empty field
                     csv.WriteField("");
                 }
             }
-            csv.NextRecord();
+            else
+            {
+                // write an empty field
+                csv.WriteField("");
+            }
         }
+        csv.NextRecord();
+    }
 
-        csv.Flush();
+    private static bool IsExportedProperty(string propertyName)
+    {
+        return propertyName != "odata.etag" && !SYSTEM_PROPERTIES.Contains(propertyName);
     }
 
 

--- a/src/Medienstudio.Azure.Data.Tables.CSV/Extensions.cs
+++ b/src/Medienstudio.Azure.Data.Tables.CSV/Extensions.cs
@@ -2,6 +2,9 @@
 using CsvHelper;
 using Medienstudio.Azure.Data.Tables.Extensions;
 using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 
 namespace Medienstudio.Azure.Data.Tables.CSV;
 
@@ -11,6 +14,10 @@ namespace Medienstudio.Azure.Data.Tables.CSV;
 public static class Extensions
 {
     const string TYPE_SUFFIX = "@type";
+    const string SCHEMA_ROW_KEY = "csv-export-schema";
+    const string SCHEMA_JSON_PROPERTY = "SchemaJson";
+    const string SOURCE_TABLE_URI_PROPERTY = "SourceTableUri";
+    const int MAX_TABLE_STRING_PROPERTY_SIZE = 64 * 1024;
     static readonly string[] SYSTEM_PROPERTIES = ["PartitionKey", "RowKey", "Timestamp"];
 
 
@@ -42,6 +49,76 @@ public static class Extensions
         }
 
         return new CsvExportSchema(properties);
+    }
+
+    /// <summary>
+    /// Gets a previously stored CSV export schema for this table.
+    /// </summary>
+    /// <param name="tableClient">The source table.</param>
+    /// <param name="metadataTableClient">A separate table that stores CSV export schemas.</param>
+    /// <returns>The stored schema, or <see langword="null"/> when no schema has been stored.</returns>
+    /// <exception cref="InvalidOperationException">The metadata table is the source table, or the stored schema is invalid.</exception>
+    public static async Task<CsvExportSchema?> GetStoredCSVExportSchemaAsync(this TableClient tableClient, TableClient metadataTableClient)
+    {
+        EnsureSeparateMetadataTable(tableClient, metadataTableClient);
+
+        global::Azure.NullableResponse<TableEntity> response = await metadataTableClient.GetEntityIfExistsAsync<TableEntity>(GetSchemaPartitionKey(tableClient), SCHEMA_ROW_KEY);
+        if (!response.HasValue)
+        {
+            return null;
+        }
+
+        TableEntity metadata = response.Value!;
+        string? schemaJson = metadata.GetString(SCHEMA_JSON_PROPERTY);
+        if (string.IsNullOrEmpty(schemaJson))
+        {
+            throw new InvalidOperationException("The stored CSV export schema is missing its property list.");
+        }
+
+        try
+        {
+            string[]? properties = JsonSerializer.Deserialize<string[]>(schemaJson);
+            return properties is null
+                ? throw new InvalidOperationException("The stored CSV export schema has an invalid property list.")
+                : new CsvExportSchema(properties);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException("The stored CSV export schema has an invalid property list.", exception);
+        }
+        catch (ArgumentException exception)
+        {
+            throw new InvalidOperationException("The stored CSV export schema has an invalid property list.", exception);
+        }
+    }
+
+    /// <summary>
+    /// Stores a CSV export schema for this table.
+    /// </summary>
+    /// <param name="tableClient">The source table.</param>
+    /// <param name="metadataTableClient">A separate table that stores CSV export schemas.</param>
+    /// <param name="schema">The schema to store.</param>
+    /// <returns>A task that represents the asynchronous store operation.</returns>
+    /// <exception cref="ArgumentException">The serialized schema exceeds the Azure Table Storage string property limit.</exception>
+    /// <exception cref="InvalidOperationException">The metadata table is the source table.</exception>
+    public static async Task StoreCSVExportSchemaAsync(this TableClient tableClient, TableClient metadataTableClient, CsvExportSchema schema)
+    {
+        EnsureSeparateMetadataTable(tableClient, metadataTableClient);
+        ArgumentNullException.ThrowIfNull(schema);
+
+        string schemaJson = JsonSerializer.Serialize(schema.Properties);
+        if (Encoding.UTF8.GetByteCount(schemaJson) > MAX_TABLE_STRING_PROPERTY_SIZE)
+        {
+            throw new ArgumentException("The serialized CSV export schema exceeds the Azure Table Storage string property limit.", nameof(schema));
+        }
+
+        TableEntity entity = new(GetSchemaPartitionKey(tableClient), SCHEMA_ROW_KEY)
+        {
+            [SCHEMA_JSON_PROPERTY] = schemaJson,
+            [SOURCE_TABLE_URI_PROPERTY] = tableClient.Uri.AbsoluteUri
+        };
+
+        await metadataTableClient.UpsertEntityAsync(entity, TableUpdateMode.Replace);
     }
 
     /// <summary>
@@ -208,6 +285,21 @@ public static class Extensions
     private static bool IsExportedProperty(string propertyName)
     {
         return propertyName != "odata.etag" && !SYSTEM_PROPERTIES.Contains(propertyName);
+    }
+
+    private static void EnsureSeparateMetadataTable(TableClient tableClient, TableClient metadataTableClient)
+    {
+        ArgumentNullException.ThrowIfNull(metadataTableClient);
+        if (tableClient.Uri == metadataTableClient.Uri)
+        {
+            throw new InvalidOperationException("The metadata table must be separate from the source table.");
+        }
+    }
+
+    private static string GetSchemaPartitionKey(TableClient tableClient)
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(tableClient.Uri.AbsoluteUri));
+        return Convert.ToHexString(hash);
     }
 
 

--- a/src/Medienstudio.Azure.Data.Tables.CSV/README.md
+++ b/src/Medienstudio.Azure.Data.Tables.CSV/README.md
@@ -26,28 +26,39 @@ TableClient tableClient = tableServiceClient.GetTableClient("tablename");
 
 // Export all rows from the table to a CSV file
 CreateTestData();
-using StreamWriter writer = File.CreateText("test.csv");
-await _tableClient.ExportCSVAsync(writer);
+using StreamWriter fileWriter = File.CreateText("test.csv");
+await tableClient.ExportCSVAsync(fileWriter);
 
 // Reuse a discovered schema to stream subsequent exports in a single table query
-CsvExportSchema schema = await _tableClient.GetCSVExportSchemaAsync();
+CsvExportSchema schema = await tableClient.GetCSVExportSchemaAsync();
 using StreamWriter schemaWriter = File.CreateText("test-with-schema.csv");
-await _tableClient.ExportCSVAsync(schemaWriter, schema);
+await tableClient.ExportCSVAsync(schemaWriter, schema);
+
+// Persist a schema in a separate metadata table for later one-query exports
+TableClient metadataTableClient = tableServiceClient.GetTableClient("csvexportmetadata");
+await metadataTableClient.CreateIfNotExistsAsync();
+await tableClient.StoreCSVExportSchemaAsync(metadataTableClient, schema);
+CsvExportSchema? storedSchema = await tableClient.GetStoredCSVExportSchemaAsync(metadataTableClient);
+if (storedSchema is not null)
+{
+    using StreamWriter storedSchemaWriter = File.CreateText("test-with-stored-schema.csv");
+    await tableClient.ExportCSVAsync(storedSchemaWriter, storedSchema);
+}
 
 // Query the table once and buffer all rows before exporting
 using StreamWriter inMemoryWriter = File.CreateText("test-in-memory.csv");
-await _tableClient.ExportCSVInMemoryAsync(inMemoryWriter);
+await tableClient.ExportCSVInMemoryAsync(inMemoryWriter);
 
-// Export all rows as CSV to Azure BLob Storage
+// Export all rows as CSV to Azure Blob Storage
 BlobContainerClient containerClient = new(BlobConnectionString, "testcontainer");
-var blobClient = containerClient.GetBlobClient("test.csv");
-var stream = await blobClient.OpenWriteAsync(true, new BlobOpenWriteOptions() { HttpHeaders = new BlobHttpHeaders { ContentType = "text/csv" } });
-using StreamWriter writer = new(stream);
-await _tableClient.ExportCSVAsync(writer);
+BlobClient blobClient = containerClient.GetBlobClient("test.csv");
+Stream blobStream = await blobClient.OpenWriteAsync(true, new BlobOpenWriteOptions() { HttpHeaders = new BlobHttpHeaders { ContentType = "text/csv" } });
+using StreamWriter blobWriter = new(blobStream);
+await tableClient.ExportCSVAsync(blobWriter);
 
 // Import all rows from a CSV file to the table
 using StreamReader reader = new("test.csv");
-await _tableClient.ImportCSVAsync(reader);
+await tableClient.ImportCSVAsync(reader);
 ```
 
-`ExportCSVAsync(writer)` discovers the table properties before streaming rows, so it queries the table twice. Reuse a `CsvExportSchema` for later one-query exports. If an entity contains a property outside the supplied schema, the export fails instead of omitting that column. A schema contains only custom table properties; system properties and `odata.etag` cannot be supplied. `ExportCSVInMemoryAsync(writer)` queries the table once, but buffers every entity and should only be used when the table fits comfortably in memory.
+`ExportCSVAsync(writer)` discovers the table properties before streaming rows, so it queries the table twice. Reuse a `CsvExportSchema` for later one-query exports. If an entity contains a property outside the supplied schema, the export fails instead of omitting that column. A schema contains only custom table properties; system properties and `odata.etag` cannot be supplied. Store schemas in a separate metadata table; the helpers use a hash of the source table URI as the metadata partition key. `ExportCSVInMemoryAsync(writer)` queries the table once, but buffers every entity and should only be used when the table fits comfortably in memory.

--- a/src/Medienstudio.Azure.Data.Tables.CSV/README.md
+++ b/src/Medienstudio.Azure.Data.Tables.CSV/README.md
@@ -29,6 +29,15 @@ CreateTestData();
 using StreamWriter writer = File.CreateText("test.csv");
 await _tableClient.ExportCSVAsync(writer);
 
+// Reuse a discovered schema to stream subsequent exports in a single table query
+CsvExportSchema schema = await _tableClient.GetCSVExportSchemaAsync();
+using StreamWriter schemaWriter = File.CreateText("test-with-schema.csv");
+await _tableClient.ExportCSVAsync(schemaWriter, schema);
+
+// Query the table once and buffer all rows before exporting
+using StreamWriter inMemoryWriter = File.CreateText("test-in-memory.csv");
+await _tableClient.ExportCSVInMemoryAsync(inMemoryWriter);
+
 // Export all rows as CSV to Azure BLob Storage
 BlobContainerClient containerClient = new(BlobConnectionString, "testcontainer");
 var blobClient = containerClient.GetBlobClient("test.csv");
@@ -40,3 +49,5 @@ await _tableClient.ExportCSVAsync(writer);
 using StreamReader reader = new("test.csv");
 await _tableClient.ImportCSVAsync(reader);
 ```
+
+`ExportCSVAsync(writer)` discovers the table properties before streaming rows, so it queries the table twice. Reuse a `CsvExportSchema` for later one-query exports. If an entity contains a property outside the supplied schema, the export fails instead of omitting that column. A schema contains only custom table properties; system properties and `odata.etag` cannot be supplied. `ExportCSVInMemoryAsync(writer)` queries the table once, but buffers every entity and should only be used when the table fits comfortably in memory.


### PR DESCRIPTION
## Summary
- Add `CsvExportSchema` and schema discovery for Azure Table CSV exports.
- Replace full-entity buffering in the default export with schema discovery followed by streaming rows.
- Add a supplied-schema overload for one-query exports and fail on schema drift rather than omitting columns.
- Add an explicit `ExportCSVInMemoryAsync` alternative for small tables where one query is preferred over bounded memory.
- Add opt-in helpers to store and retrieve ordered schemas from a caller-provided metadata table, keyed by a hash of the source table URI.
- Reject system properties in supplied schemas, and cover empty exports, schema drift, `odata.etag` exclusion, output equivalence, stored-schema replacement, and schema validation.
- Make the import round-trip test self-contained rather than dependent on test execution order.

## Validation
- `dotnet test src/Medienstudio.Azure.Data.Tables.CSV.Tests/Medienstudio.Azure.Data.Tables.CSV.Tests.csproj --no-restore` (14 passed)