### PR TITLE
Fix table extension filtering edge cases and batching efficiency

### DIFF
--- a/src/Medienstudio.Azure.Data.Tables.Extensions.Tests/ExtensionTests.cs
+++ b/src/Medienstudio.Azure.Data.Tables.Extensions.Tests/ExtensionTests.cs
@@ -182,6 +182,15 @@ public class ExtensionTests
         Assert.AreEqual(1, entities2.Count);
     }
 
+    [TestMethod]
+    public async Task GetAllEntitiesStartingWithEmptyPrefixTest()
+    {
+        CreateTestData();
+
+        List<TableEntity> entities = await _tableClient.GetAllEntitiesStartingWithAsync<TableEntity>("PartitionKey", string.Empty);
+
+        Assert.AreEqual(3003, entities.Count);
+    }
 
     [TestMethod]
     public async Task TestEntitiesCount()

--- a/src/Medienstudio.Azure.Data.Tables.Extensions.Tests/ExtensionTests.cs
+++ b/src/Medienstudio.Azure.Data.Tables.Extensions.Tests/ExtensionTests.cs
@@ -193,6 +193,18 @@ public class ExtensionTests
     }
 
     [TestMethod]
+    public async Task GetAllEntitiesStartingWithApostropheTest()
+    {
+        _tableClient.UpsertEntity(new TableEntity("quote'", "first"));
+        _tableClient.UpsertEntity(new TableEntity("quote'prefix", "second"));
+        _tableClient.UpsertEntity(new TableEntity("quotez", "third"));
+
+        List<TableEntity> entities = await _tableClient.GetAllEntitiesStartingWithAsync<TableEntity>("PartitionKey", "quote'");
+
+        Assert.AreEqual(2, entities.Count);
+    }
+
+    [TestMethod]
     public async Task TestEntitiesCount()
     {
         CreateTestData();
@@ -201,6 +213,10 @@ public class ExtensionTests
 
         int count2 = await _tableClient.CountEntitiesAsync(partitionKey: "123");
         Assert.AreEqual(3000, count2);
+
+        _tableClient.UpsertEntity(new TableEntity("quote'", "count"));
+        int count3 = await _tableClient.CountEntitiesAsync(partitionKey: "quote'");
+        Assert.AreEqual(1, count3);
     }
 
     [TestCleanup]

--- a/src/Medienstudio.Azure.Data.Tables.Extensions.Tests/HelpersTests.cs
+++ b/src/Medienstudio.Azure.Data.Tables.Extensions.Tests/HelpersTests.cs
@@ -53,6 +53,9 @@ public class HelpersTests
         filter = Helpers.StartsWith("column", "prefix-");
         Assert.AreEqual("column ge 'prefix-' and column lt 'prefix.'", filter);
 
+        filter = Helpers.StartsWith("column", "prefix'");
+        Assert.AreEqual("column ge 'prefix''' and column lt 'prefix('", filter);
+
         string prefix = "prefix" + char.MaxValue;
         filter = Helpers.StartsWith("column", prefix);
         Assert.AreEqual("column ge '" + prefix + "'", filter);

--- a/src/Medienstudio.Azure.Data.Tables.Extensions/Extensions.cs
+++ b/src/Medienstudio.Azure.Data.Tables.Extensions/Extensions.cs
@@ -228,7 +228,7 @@ public static class Extensions
     public static async Task<int> CountEntitiesAsync(this TableClient tableClient, string? partitionKey = null)
     {
         ArgumentNullException.ThrowIfNull(tableClient);
-        string? filter = partitionKey is null ? null : $"PartitionKey eq '{partitionKey.Replace("'", "''")}'";
+        string? filter = partitionKey is null ? null : TableClient.CreateQueryFilter($"PartitionKey eq {partitionKey}");
         IAsyncEnumerable<Page<TableEntity>> pages = tableClient
             .QueryAsync<TableEntity>(filter: filter, select: ["PartitionKey"], maxPerPage: 1000)
             .AsPages();

--- a/src/Medienstudio.Azure.Data.Tables.Extensions/Extensions.cs
+++ b/src/Medienstudio.Azure.Data.Tables.Extensions/Extensions.cs
@@ -15,18 +15,23 @@ public static class Extensions
     /// <returns>List of Azure Responses for Transactions</returns>
     public static async Task<List<Response<IReadOnlyList<Response>>>> BatchManipulateEntities<T>(TableClient tableClient, IEnumerable<T> entities, TableTransactionActionType tableTransactionActionType) where T : class, ITableEntity, new()
     {
-        IEnumerable<IGrouping<string, T>> groups = entities.GroupBy(x => x.PartitionKey);
-        List<Response<IReadOnlyList<Response>>> responses = [];
-        foreach (IGrouping<string, T> group in groups)
-        {
-            List<TableTransactionAction> actions;
-            IEnumerable<T> items = group.AsEnumerable();
-            while (items.Any())
-            {
-                IEnumerable<T> batch = items.Take(100);
-                items = items.Skip(100);
+        ArgumentNullException.ThrowIfNull(tableClient);
+        ArgumentNullException.ThrowIfNull(entities);
 
-                actions = [.. batch.Select(e => new TableTransactionAction(tableTransactionActionType, e))];
+        List<T> entityList = [.. entities];
+        if (entityList.Count == 0)
+        {
+            return [];
+        }
+
+        List<Response<IReadOnlyList<Response>>> responses = [];
+        foreach (IGrouping<string, T> group in entityList.GroupBy(x => x.PartitionKey, StringComparer.Ordinal))
+        {
+            List<T> partitionEntities = [.. group];
+            for (int index = 0; index < partitionEntities.Count; index += 100)
+            {
+                List<T> batch = partitionEntities.GetRange(index, Math.Min(100, partitionEntities.Count - index));
+                List<TableTransactionAction> actions = [.. batch.Select(e => new TableTransactionAction(tableTransactionActionType, e))];
                 Response<IReadOnlyList<Response>> response = await tableClient.SubmitTransactionAsync(actions).ConfigureAwait(false);
                 responses.Add(response);
             }
@@ -43,6 +48,8 @@ public static class Extensions
     /// <returns>List of all entities with specified PartitionKey</returns>
     public static async Task<List<T>> GetAllEntitiesByPartitionKeyAsync<T>(this TableClient tableClient, string partitionKey) where T : class, ITableEntity, new()
     {
+        ArgumentNullException.ThrowIfNull(tableClient);
+        ArgumentNullException.ThrowIfNull(partitionKey);
         return await tableClient.QueryAsync<T>(x => x.PartitionKey == partitionKey, maxPerPage: 1000).ToListAsync().ConfigureAwait(false);
     }
 
@@ -56,6 +63,9 @@ public static class Extensions
     /// <returns></returns>
     public static async Task<List<T>> GetAllEntitiesStartingWithAsync<T>(this TableClient tableClient, string column, string prefix) where T : class, ITableEntity, new()
     {
+        ArgumentNullException.ThrowIfNull(tableClient);
+        ArgumentNullException.ThrowIfNull(column);
+        ArgumentNullException.ThrowIfNull(prefix);
         return await tableClient.QueryAsync<T>(Helpers.StartsWith(column, prefix), maxPerPage: 1000).ToListAsync().ConfigureAwait(false);
     }
 
@@ -69,6 +79,8 @@ public static class Extensions
     /// <returns>List of all entities in the table with specified RowKey</returns>
     public static async Task<List<T>> GetAllEntitiesByRowKeyAsync<T>(this TableClient tableClient, string rowKey) where T : class, ITableEntity, new()
     {
+        ArgumentNullException.ThrowIfNull(tableClient);
+        ArgumentNullException.ThrowIfNull(rowKey);
         return await tableClient.QueryAsync<T>(x => x.RowKey == rowKey, maxPerPage: 1000).ToListAsync().ConfigureAwait(false);
     }
 
@@ -80,6 +92,7 @@ public static class Extensions
     /// <returns></returns>
     public static async Task<List<T>> GetAllEntitiesAsync<T>(this TableClient tableClient) where T : class, ITableEntity, new()
     {
+        ArgumentNullException.ThrowIfNull(tableClient);
         return await tableClient.QueryAsync<T>(maxPerPage: 1000).ToListAsync().ConfigureAwait(false);
     }
 
@@ -91,6 +104,7 @@ public static class Extensions
     /// <returns>First entity in table</returns>
     public static async Task<T?> GetFirstEntityAsync<T>(this TableClient tableClient) where T : class, ITableEntity, new()
     {
+        ArgumentNullException.ThrowIfNull(tableClient);
         return await tableClient.QueryAsync<T>(maxPerPage: 1).FirstOrDefaultAsync();
     }
 
@@ -103,6 +117,8 @@ public static class Extensions
     /// <returns>First entity in partition</returns>
     public static async Task<T?> GetFirstEntityAsync<T>(this TableClient tableClient, string partitionKey) where T : class, ITableEntity, new()
     {
+        ArgumentNullException.ThrowIfNull(tableClient);
+        ArgumentNullException.ThrowIfNull(partitionKey);
         return await tableClient.QueryAsync<T>(filter: x => x.PartitionKey == partitionKey, maxPerPage: 1).FirstOrDefaultAsync();
     }
 
@@ -116,6 +132,8 @@ public static class Extensions
     /// <returns></returns>
     public static async Task AddEntitiesAsync<T>(this TableClient tableClient, IEnumerable<T> entities, TableTransactionActionType tableTransactionActionType = TableTransactionActionType.Add) where T : class, ITableEntity, new()
     {
+        ArgumentNullException.ThrowIfNull(tableClient);
+        ArgumentNullException.ThrowIfNull(entities);
         await BatchManipulateEntities(tableClient, entities, tableTransactionActionType).ConfigureAwait(false);
     }
 
@@ -126,6 +144,8 @@ public static class Extensions
     /// <returns></returns>
     public static async Task DeleteAllEntitiesAsync(this TableClient tableClient)
     {
+        ArgumentNullException.ThrowIfNull(tableClient);
+
         // Only the PartitionKey & RowKey fields are required for deletion
         AsyncPageable<TableEntity> entities = tableClient
             .QueryAsync<TableEntity>(select: ["PartitionKey", "RowKey"], maxPerPage: 1000);
@@ -146,6 +166,9 @@ public static class Extensions
     /// <returns></returns>
     public static async Task DeleteAllEntitiesByPartitionKeyAsync(this TableClient tableClient, string partitionKey)
     {
+        ArgumentNullException.ThrowIfNull(tableClient);
+        ArgumentNullException.ThrowIfNull(partitionKey);
+
         // Only the PartitionKey & RowKey fields are required for deletion
         AsyncPageable<TableEntity> entities = tableClient
             .QueryAsync<TableEntity>(x => x.PartitionKey == partitionKey, select: ["PartitionKey", "RowKey"], maxPerPage: 1000);
@@ -166,6 +189,9 @@ public static class Extensions
     /// <returns>Azure Response, null if table already existed</returns>
     public static async Task<Response<TableItem>?> CreateTableIfNotExistsSafeAsync(this TableServiceClient tableServiceClient, string table)
     {
+        ArgumentNullException.ThrowIfNull(tableServiceClient);
+        ArgumentNullException.ThrowIfNull(table);
+
         List<TableItem> tables = await tableServiceClient.QueryAsync(x => x.Name == table).ToListAsync().ConfigureAwait(false);
         if (tables.Count == 0)
         {
@@ -182,6 +208,9 @@ public static class Extensions
     /// <returns>Azure Response, null if table already existed</returns>
     public static Response<TableItem>? CreateTableIfNotExistsSafe(this TableServiceClient tableServiceClient, string table)
     {
+        ArgumentNullException.ThrowIfNull(tableServiceClient);
+        ArgumentNullException.ThrowIfNull(table);
+
         List<TableItem> tables = tableServiceClient.Query(x => x.Name == table).ToList();
         if (tables.Count == 0)
         {
@@ -198,7 +227,8 @@ public static class Extensions
     /// <returns>The total number of rows in the table</returns>
     public static async Task<int> CountEntitiesAsync(this TableClient tableClient, string? partitionKey = null)
     {
-        string? filter = partitionKey is null ? null : TableClient.CreateQueryFilter($"PartitionKey eq {partitionKey}");
+        ArgumentNullException.ThrowIfNull(tableClient);
+        string? filter = partitionKey is null ? null : $"PartitionKey eq '{partitionKey.Replace("'", "''")}'";
         IAsyncEnumerable<Page<TableEntity>> pages = tableClient
             .QueryAsync<TableEntity>(filter: filter, select: ["PartitionKey"], maxPerPage: 1000)
             .AsPages();

--- a/src/Medienstudio.Azure.Data.Tables.Extensions/Helpers.cs
+++ b/src/Medienstudio.Azure.Data.Tables.Extensions/Helpers.cs
@@ -53,20 +53,21 @@ public static class Helpers
         ArgumentNullException.ThrowIfNull(column);
         ArgumentNullException.ThrowIfNull(prefix);
 
-        string escapedPrefix = prefix.Replace("'", "''");
-        if (escapedPrefix.Length == 0)
+        if (prefix.Length == 0)
         {
             return $"{column} ge ''";
         }
 
-        char lastChar = escapedPrefix[^1];
+        string escapedPrefix = prefix.Replace("'", "''");
+        char lastChar = prefix[^1];
         if (lastChar == char.MaxValue)
         {
             return $"{column} ge '{escapedPrefix}'";
         }
 
         char nextChar = (char)(lastChar + 1);
-        string prefixNext = escapedPrefix[..^1] + nextChar;
-        return $"{column} ge '{escapedPrefix}' and {column} lt '{prefixNext}'";
+        string prefixNext = prefix[..^1] + nextChar;
+        string escapedPrefixNext = prefixNext.Replace("'", "''");
+        return $"{column} ge '{escapedPrefix}' and {column} lt '{escapedPrefixNext}'";
     }
 }

--- a/src/Medienstudio.Azure.Data.Tables.Extensions/Helpers.cs
+++ b/src/Medienstudio.Azure.Data.Tables.Extensions/Helpers.cs
@@ -50,13 +50,23 @@ public static class Helpers
     /// <returns></returns>
     public static string StartsWith(string column, string prefix)
     {
-        char lastChar = prefix[prefix.Length - 1];
+        ArgumentNullException.ThrowIfNull(column);
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        string escapedPrefix = prefix.Replace("'", "''");
+        if (escapedPrefix.Length == 0)
+        {
+            return $"{column} ge ''";
+        }
+
+        char lastChar = escapedPrefix[^1];
         if (lastChar == char.MaxValue)
         {
-            return $"{column} ge '{prefix}'";
+            return $"{column} ge '{escapedPrefix}'";
         }
+
         char nextChar = (char)(lastChar + 1);
-        string prefixNext = prefix[..^1] + nextChar;
-        return $"{column} ge '{prefix}' and {column} lt '{prefixNext}'";
+        string prefixNext = escapedPrefix[..^1] + nextChar;
+        return $"{column} ge '{escapedPrefix}' and {column} lt '{prefixNext}'";
     }
 }


### PR DESCRIPTION
## Summary
- fix starts-with OData filter generation for empty prefixes
- escape single quotes in starts-with and count filters
- optimize transaction batching by materializing once and slicing in bounded chunks
- add null guards across extension entrypoints
- add regression test for empty-prefix starts-with queries

## Validation
- dotnet test src/Medienstudio.Azure.Data.Tables.Extensions.Tests/Medienstudio.Azure.Data.Tables.Extensions.Tests.csproj
