### PR TITLE
Fix CI: TableEntity.Add doesn't throw on duplicate CSV columns

### DIFF
--- a/src/Medienstudio.Azure.Data.Tables.CSV/Extensions.cs
+++ b/src/Medienstudio.Azure.Data.Tables.CSV/Extensions.cs
@@ -521,15 +521,13 @@ public static class Extensions
                             throw new InvalidDataException($"CSV import failed at row {rowIndex}, column '{label}', declared type '{type ?? "String"}'.", ex);
                         }
 
-                        try
+                        if (entity.ContainsKey(label))
                         {
-                            entity.Add(label, value);
-                        }
-                        catch (ArgumentException ex)
-                        {
+                            ArgumentException ex = new($"An item with the same key has already been added. Key: {label}", nameof(label));
                             logger.LogWarning(LogEvents.CsvImportInvalidColumn, ex, "CSV import failed for table {TableName}: invalid column {ColumnName} at row {RowIndex}.", tableClient.Name, label, rowIndex);
                             throw new InvalidDataException($"CSV import failed at row {rowIndex}, column '{label}'.", ex);
                         }
+                        entity.Add(label, value);
                     }
                 }
 


### PR DESCRIPTION
## Summary

CI on `main` has been red since the #27 merge (commit `09ec10f`): the "Test CSV Extensions" job fails with `Failed: 1, Passed: 22, Total: 23`. The failing test is `TestImportDuplicateColumnLogsColumnError`:

```
Assert.ThrowsExceptionAsync failed. Expected exception type: <System.IO.InvalidDataException> but no exception was thrown.
```

## Root cause

`ImportCSVAsync` wraps `entity.Add(label, value)` in `catch (ArgumentException ex)`, assuming it behaves like `Dictionary<TKey,TValue>.Add` and throws on a duplicate key. It doesn't: `Azure.Data.Tables.TableEntity.Add` delegates to an internal `SetValue`/indexer path (`_properties[key] = value`) and **silently overwrites** an existing key instead of throwing. I confirmed this directly against the `Azure.Data.Tables` package with a standalone repro (`entity.Add("value","first"); entity.Add("value","second");` → no exception, `entity["value"] == "second"`).

So the `catch (ArgumentException)` added in #27 to detect duplicate/invalid CSV columns was dead code, and a CSV with a duplicated column name would silently keep only the last value instead of raising the contextual error the PR was meant to add — regressing back to the exact class of silent-failure bug #24/#25/#27 set out to fix.

## Fix

Replace the try/catch with an explicit `entity.ContainsKey(label)` check before adding, so the duplicate-column warning + `InvalidDataException` path (`CsvImportInvalidColumn`) actually fires as intended. No test changes needed — the existing `TestImportDuplicateColumnLogsColumnError` regression test now passes as originally written.

## How this was found

The CI logs for the failing run didn't include per-test failure detail (Microsoft.Testing.Platform writes it to a `TestResults/*.log` file, not stdout, and the workflow doesn't upload it as an artifact). Installed `dotnet-sdk-10.0` + `azurite` locally, reproduced the exact CI failure against `main` (`09ec10f`), then read the detailed `.log` file to get the real assertion failure, and verified the fix with `dotnet test` on both test projects (23/23 CSV, 18/18 Extensions).

## Test plan

- [x] `dotnet build src/Medienstudio.Azure.Data.Tables.Extensions.sln -c Release` — succeeds
- [x] `dotnet test src/Medienstudio.Azure.Data.Tables.CSV.Tests/...` — 23/23 passing (was 22/23)
- [x] `dotnet test src/Medienstudio.Azure.Data.Tables.Extensions.Tests/...` — 18/18 passing (unaffected)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ARPN3fZs61MAGHoxcDRUa)_