### PR TITLE
ci: allow manual workflow_dispatch to run the publish job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.tag_name || github.sha }}
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
## Summary
- Adds a manual escape hatch so the `publish` job in `.github/workflows/main.yml` can be triggered directly via `workflow_dispatch`, not only when the `release-please` job reports `release_created == true`.
- Needed as a one-time bootstrap: `2.0.0` was never actually tagged or published to NuGet (last published version is 1.5.0), and no `v2.0.0` git tag exists for `release-please` to anchor a real release for it (see discussion on #31). This lets us manually fire `publish` once to push `2.0.0` for both packages via the existing OIDC trusted-publishing step, without inventing a fake release-please release.
- Also useful going forward as a manual re-publish escape hatch if a `publish` run ever needs to be retried outside the normal release-please flow.

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger the `CI` workflow via `workflow_dispatch` on `main` and confirm the `publish` job runs, authenticates via `NuGet/login@v1`, and pushes `Medienstudio.Azure.Data.Tables.Extensions` and `Medienstudio.Azure.Data.Tables.CSV` at version 2.0.0 to NuGet
- [ ] Confirm nuget.org shows 2.0.0 as the latest version for both packages

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NGz4GmLHS6Ss426VPJBCrT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGz4GmLHS6Ss426VPJBCrT)_