### PR TITLE
fix: publish job was silently skipped on workflow_dispatch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,8 +71,8 @@ jobs:
           manifest-file: .release-please-manifest.json
 
   publish:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
+    needs: [build, release-please]
+    if: ${{ always() && needs.build.result == 'success' && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- The `publish` job's `if` condition included `github.event_name == 'workflow_dispatch'`, but since it only listed `needs: release-please` and `release-please` is itself skipped on `workflow_dispatch` events (it only runs on `push`), GitHub Actions auto-skipped `publish` too — a custom `if:` does not override the default "skip if a needed job was skipped" behavior unless wrapped in `always()`. Confirmed in run [31280120724](https://github.com/ThomasPe/Azure.Data.Tables-Extensions/actions/runs/31280120724): `build` succeeded, but `publish` and `release-please` both show `skipped`.
- Fix: `publish` now also depends on `build` directly and wraps the condition in `always() && needs.build.result == 'success' && (...)`, so it evaluates regardless of `release-please`'s skip status while still requiring `build` to have actually succeeded in both the automated (release-please) and manual (workflow_dispatch) paths.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger `workflow_dispatch` on `main` and confirm `publish` now actually runs and pushes 2.0.0 to NuGet for both packages

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NGz4GmLHS6Ss426VPJBCrT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGz4GmLHS6Ss426VPJBCrT)_