### PR TITLE
Bump GitHub Actions to latest majors to run on Node.js 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
       - name: Install & run Azurite
         run: npm install -g azurite
         # https://github.com/Azure/Azurite/issues/451#issuecomment-639398801

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.x
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20.x'
       - name: Install & run Azurite
@@ -78,11 +78,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.release-please.outputs.tag_name || github.sha }}
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.x
       - name: Build packages


### PR DESCRIPTION
## Summary

- `actions/checkout@v4`, `actions/setup-dotnet@v4`, and `actions/setup-node@v4` still target the deprecated Node.js 20 runtime, which GitHub Actions runners are now forcing onto Node 24 (see [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
- Bumped to `actions/checkout@v7`, `actions/setup-dotnet@v6`, and `actions/setup-node@v7` in both the `build` and `publish` jobs — all of these ship their own Node 24 runtime.

## Test plan

- [ ] CI workflow run passes on this PR (build, test, and — where applicable — publish jobs)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbA5CkfCEpPF1fuwYbgqKT)_